### PR TITLE
Made some visual tweaks and added ability to have instructions for Google Calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+### Jekyll ###
+_site/
+.sass-cache/

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,16 @@ titleBackground: "https://s3-us-west-2.amazonaws.com/webmaker-kits/learning%402x
 headlineSmall: "Welcome To the Scientific Programming Study Group at SFU!"
 headlineMain: "Let's Work Together"
 
+# Setup Google Calendar
+# Create Google Acount and add events to a new calendar.
+# Here are example URLs:
+# calendar_embed_url: https://www.google.com/calendar/embed?src=email@gmail.com
+# calendar_ical_url: https://www.google.com/calendar/ical/email@gmail.com/public/basic.ics
+
+calendar_on: Yes
+calendar_embed_url: "https://www.google.com/calendar/embed?src=sciprogrammingstudygroupsfu@gmail.com"
+calendar_ical_url: "https://www.google.com/calendar/ical/sciprogrammingstudygroupsfu@gmail.com/public/basic.ics"
+
 
 #========================================
 # No touching anything below this line :)

--- a/_config.yml
+++ b/_config.yml
@@ -5,14 +5,14 @@
 user: ttimbers
 
 #Step 2: give your study group a name and a short description:
-title: SFU Scientific Programming Study Group
-description: "A scientific computing study group whose home-base is at Simon Fraser 
+title: Scientific Programming Study Group at SFU
+description: "A scientific computing study group whose home base is at Simon Fraser
 University (SFU) in Burnaby, BC, Canada. Our group meets on a weekly basis for peer-
 facilitated study-sessions on topics under the broad umbrella of using computers to do
 scientific research more effectively and efficiently. This includes using Python for DNA
-sequence analysis, plotting and statistical analysis of environmental data in R, 
-automating repetitive tasks with the shell, general best practices in coding, and to using 
-tools such as Git and Github to collaborate effectively with others. All are welcome to 
+sequence analysis, plotting and statistical analysis of environmental data in R,
+automating repetitive tasks with the shell, general best practices in coding, and to using
+tools such as Git and Github to collaborate effectively with others. All are welcome to
 this study group, regardless of affiliation or training level."
 
 #Step 3: press the green 'Commit Changes' button at the bottom of this page.
@@ -27,7 +27,7 @@ this study group, regardless of affiliation or training level."
 # None of these things need to be changed - but feel free!
 
 titleBackground: "https://s3-us-west-2.amazonaws.com/webmaker-kits/learning%402x.jpg"
-headlineSmall: "Welcome To the SFU  Programming Study Group!"
+headlineSmall: "Welcome To the Scientific Programming Study Group at SFU!"
 headlineMain: "Let's Work Together"
 
 

--- a/_includes/css/custom.css
+++ b/_includes/css/custom.css
@@ -1,0 +1,29 @@
+/* Improve general readability */
+
+section h3.section-subheading {
+    line-height: 1.75;
+    margin-bottom: 50px;
+}
+
+.intro-lead-in {
+      text-shadow: 0px 0px 5px rgba(0, 0, 0, 0.8);
+}
+
+.intro-heading {
+      text-shadow: 0px 0px 10px rgba(0, 0, 0, 0.8);
+}
+
+/* Improve formatting of events */
+
+ul.events li {
+    margin-bottom: 1.8em;
+}
+
+a.eventTitle {
+  margin-bottom: 0.3em;
+  display: inline-block;
+}
+
+.eventSub {
+    font-size: 1.2em;
+}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,10 +8,10 @@
 
 
     <!-- Custom CSS & Bootstrap Core CSS - Uses Bootswatch Flatly Theme: https://bootswatch.com/flatly/ -->
-    <link rel="stylesheet" href="https://{{ site.user }}.github.io/studyGroup/style.css">
+    <link rel="stylesheet" href="style.css">
 
     <!-- Custom Fonts -->
-    <link rel="stylesheet" href="https://{{ site.user }}.github.io/studyGroup/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="css/font-awesome/css/font-awesome.min.css">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">

--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -10,7 +10,7 @@
             <div class="col-lg-12">
               <ul class='events'>
               {% assign isEvent = 0 %}
-              {% for post in site.posts reversed %}
+              {% for post in site.posts reversed limit:5 %}
                 {% capture nowyear %}{{'now' | date: '%Y'}}{% endcapture %}
                 {% capture postyear %}{{post.date | date: '%Y'}}{% endcapture %}
                 {% capture nowday %}{{'now' | date: '%j'}}{% endcapture %}
@@ -37,7 +37,11 @@
               {% endif %}
               </ul>
             </div>
+            {% if site.calendar_on %}
+            <div class="col-lg-6">
+            {% else %}
             <div class="col-lg-12">
+            {% endif %}
               <h3 class="section-heading eventInstructions">Want to be notified of our upcoming events?</h3>
               <h3 class="section-subheading text-muted eventSubinstructions">Head over to <a href="{{ '/studyGroup' | prepend: site.user | prepend: 'https://github.com/' }}">GitHub</a> and watch our repository, like this:</h3>
               <figure>
@@ -45,5 +49,13 @@
                 <figcaption>Look in the top right-hand corner of <a href="{{ '/studyGroup' | prepend: site.user | prepend: 'https://github.com/' }}">our repo</a>, and click 'Watching.' <br>You can undo this at any time in the same place.</figcaption>
               </figure>
             </div>
+            {% if site.calendar_on %}
+            <div class="col-lg-6">
+              <h3 class="section-heading eventInstructions">Subscribe to our events calendar!</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">We also invite you to follow <a href="{{ site.calendar_embed_url }}" target="_blank">our calendar</a>, where events will be posted. </h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">If you use Google calendar, you can add our calendar by pressing the "Google Calendar" button at the bottom-right of <a href="{{ site.calendar_embed_url }}" target="_blank">this page</a>.</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">If you use another calendar app, you can copy and paste <a href="{{ site.calendar_ical_url }}">this address</a> into any calendar product that supports the iCal format.</h3>
+            </div>
+            {% endif %}
         </div>
     </section>

--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -10,7 +10,11 @@
             <div class="col-lg-12">
               <ul class='events'>
               {% assign isEvent = 0 %}
-              {% for post in site.posts reversed limit:5 %}
+              {% assign eventcount = 0 %}
+              {% for post in site.posts reversed %}
+                {% if eventcount >= 5 %}
+                   {% break %}
+                {% endif %}
                 {% capture nowyear %}{{'now' | date: '%Y'}}{% endcapture %}
                 {% capture postyear %}{{post.date | date: '%Y'}}{% endcapture %}
                 {% capture nowday %}{{'now' | date: '%j'}}{% endcapture %}
@@ -19,6 +23,7 @@
                 {% assign nowday = nowday | minus: 2 %}
                 {% if postyear > nowyear or postday >= nowday and postyear >= nowyear %}
                   {% assign isEvent = 1 %}
+                  {% assign eventcount = eventcount | plus: 1 %}
                   <li>
                     <a class='eventTitle' href="{{ post.link }}">{{ post.title }}, {{ post.location }}, {{ post.date | date: "%-d %B %Y"}}</a>
                     <div class='eventSub'>{{ post.text }}</div>

--- a/_layouts/style.css
+++ b/_layouts/style.css
@@ -1,2 +1,3 @@
 {% include css/bootstrap.min.css %}
 {% include css/agency.css %}
+{% include css/custom.css %}


### PR DESCRIPTION
Instead of making edits to the "master" branch (for this repo, gh-pages) directly, maybe we should move to a more organized system, such as Git Flow. It's easy to use. 

Here, I've created some improvements that you should be able to preview locally if you checkout the `release/1.0.1` branch and run `jekyll serve` in your repository. 

I made a few visual tweaks, mostly spacing-wise and I limited the number of events to five, as the list gets a bit too long otherwise. I also added some settings in the config to setup a Google Calendar with instructions on the website. 

Let me know what you think by commenting this pull request and if you're okay with it, we can merge it with gh-pages. 
